### PR TITLE
Works!

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const isDOM = require('is-dom');
 const isFunction = require('is-function');
-let pervScrollTop = 0;
+let prevScrollTop = 0;
 
 module.exports = (element,cb) => {
   
@@ -14,14 +14,9 @@ module.exports = (element,cb) => {
   }
 
   element.addEventListener('scroll',() => { 
-     let currentScrollTop = window.pageYOffset || document.documentElement.scrollTop;
-     if (currentScrollTop > pervScrollTop) {
-        pervScrollTop = currentScrollTop;
-        return cb(0);
-     } else {
-        pervScrollTop = currentScrollTop;
-        return cb(1);
-     }
-     pervScrollTop = currentScrollTop;
+    let currentScrollTop = element.scrollTop;
+    let dir = currentScrollTop > prevScrollTop ? 0 : 1;
+    prevScrollTop = currentScrollTop;
+    return cb(dir);
   }, false);
 };


### PR DESCRIPTION
My understanding is that it should report scrolling within an element. Say I have a div that has content too long for it's height and it displays a scrollbar. The page itself may be long and have scrollbars. When I attach a listener to the div, I expect it to be fired when I scroll the contents in the div and not when I scroll the page. For page scroll, I would attach a listener on the page. It still doesn't work for the document element. Will fix it if needed.
